### PR TITLE
Add digilent hs2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ pkg_check_modules(FTDI REQUIRED libftdi1)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS_DEBUG "-fsanitize=address ${CMAKE_CXX_FLAGS_DEBUG}")
 
-add_executable(jtag-remote-server src/main.cpp src/xvc.cpp src/rbb.cpp src/common.cpp src/vpi.cpp src/jtagd.cpp src/mpsse.cpp src/usb_blaster.cpp)
+add_executable(jtag-remote-server src/main.cpp src/xvc.cpp src/rbb.cpp src/common.cpp src/vpi.cpp src/jtagd.cpp src/mpsse.cpp src/mpsse_buffer.cpp src/usb_blaster.cpp)
 target_link_libraries(jtag-remote-server ${FTDI_LDFLAGS})
 target_include_directories(jtag-remote-server PUBLIC ${FTDI_INCLUDE_DIRS})
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -460,7 +460,7 @@ bool jtag_tms_seq_to(JtagState to) {
   }
 }
 
-bool adapter_init() { return adapter->init(); }
+bool adapter_init(enum AdapterTypes adapter_type) { return adapter->init(adapter_type); }
 
 bool adapter_deinit() { return adapter->deinit(); }
 

--- a/src/common.h
+++ b/src/common.h
@@ -36,6 +36,11 @@ enum JtagState {
   UpdateIR,
 };
 
+enum AdapterTypes {
+  Adapter_Xilinx,
+  Adapter_DigilentHS2,
+};
+
 extern JtagState state;
 extern uint64_t bits_send;
 extern uint64_t freq_mhz;
@@ -51,7 +56,7 @@ const char *state_to_string(JtagState state);
 
 // functions for adapter driver
 struct driver {
-  bool (*init)();
+  bool (*init)(enum AdapterTypes adapter_type);
   bool (*deinit)();
   bool (*set_tck_freq)(uint64_t freq_mhz);
 
@@ -65,7 +70,7 @@ struct driver {
 extern driver *adapter;
 
 // adapter operations
-bool adapter_init();
+bool adapter_init(enum AdapterTypes adapter_type);
 bool adapter_deinit();
 bool adapter_set_tck_freq(uint64_t freq_mhz);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@ bool debug = false;
 int ftdi_vid = 0x0403;
 int ftdi_pid = 0x6011;
 enum ftdi_interface ftdi_channel = INTERFACE_A;
+enum AdapterTypes adapter_type = Adapter_Xilinx;
 bool stop = false;
 uint64_t bits_send = 0;
 uint64_t freq_mhz = 15;
@@ -46,7 +47,7 @@ int main(int argc, char *argv[]) {
   // https://man7.org/linux/man-pages/man3/getopt.3.html
   int opt;
   Protocol proto = Protocol::VPI;
-  while ((opt = getopt(argc, argv, "dvrxjbc:V:p:f:")) != -1) {
+  while ((opt = getopt(argc, argv, "dvrxjbc:V:p:f:a:")) != -1) {
     switch (opt) {
     case 'd':
       debug = true;
@@ -62,6 +63,18 @@ int main(int argc, char *argv[]) {
       break;
     case 'j':
       proto = Protocol::JTAGD;
+      break;
+    case 'a':
+      if (strcmp(optarg, "Xilinx") == 0) {
+        adapter_type = Adapter_Xilinx;
+      }
+      else if (strcmp(optarg, "hs2") == 0) {
+        ftdi_pid = 0x6014;
+        adapter_type = Adapter_DigilentHS2;
+      }
+      else {
+        printf("Unknown adapter\n");
+      }
       break;
     case 'b':
       adapter = &usb_blaster_driver;
@@ -88,6 +101,7 @@ int main(int argc, char *argv[]) {
       fprintf(stderr, "\t-r: Use remote bitbang protocol\n");
       fprintf(stderr, "\t-x: Use xilinx virtual cable protocol\n");
       fprintf(stderr, "\t-j: Use intel jtag server protocol\n");
+      fprintf(stderr, "\t-a Xilinx|hs2: Use Xilinx (default) or Digilent HS2 adapter\n");
       fprintf(stderr, "\t-b: Use USB Blaster adapter\n");
       fprintf(stderr, "\t-c A|B|C|D: Select ftdi channel\n");
       fprintf(stderr, "\t-V VID: Specify usb vid\n");
@@ -97,7 +111,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  if (!adapter_init()) {
+  if (!adapter_init(adapter_type)) {
     return 1;
   }
 

--- a/src/mpsse.h
+++ b/src/mpsse.h
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 
 // initialize mpsse interface of ftdi
-bool mpsse_init();
+bool mpsse_init(enum AdapterTypes adapter_type);
 bool mpsse_deinit();
 bool mpsse_set_tck_freq(uint64_t freq_mhz);
 

--- a/src/mpsse_buffer.cpp
+++ b/src/mpsse_buffer.cpp
@@ -1,0 +1,48 @@
+#include <stdlib.h>
+#include "mpsse_buffer.h"
+#include "common.h"
+#include "ftdi.h"
+
+#define BUFFER_LENGTH 16384
+static uint8_t mpsse_buffer[BUFFER_LENGTH];
+static size_t mpsse_buffer_pos = 0;
+static struct ftdi_context* mpsse_ftdi = NULL;
+
+void mpsse_buffer_init(struct ftdi_context *ftdi)
+{
+  mpsse_buffer_pos = 0;
+  mpsse_ftdi = ftdi;
+}
+
+bool mpsse_buffer_flush() {
+  if (!mpsse_buffer_pos)
+    return true;
+  dprintf("mpsse_buffer_flush %zu bytes\n", mpsse_buffer_pos);
+  if (!ftdi_write_retry(mpsse_ftdi, mpsse_buffer, mpsse_buffer_pos)) {
+    printf("Error writing %zu bytes @ %s:%d : %s\n", mpsse_buffer_pos, __FILE__, __LINE__,
+           ftdi_get_error_string(mpsse_ftdi));
+    mpsse_buffer_pos = 0;
+    return false;
+  }
+  mpsse_buffer_pos = 0;
+  return true;
+}
+
+bool mpsse_buffer_ensure_space(size_t num_bytes) {
+  if (num_bytes >= BUFFER_LENGTH) {
+    printf("MPSSE buffer too small\n");
+    return false;
+  }
+  if(mpsse_buffer_pos + num_bytes >= BUFFER_LENGTH)
+    return mpsse_buffer_flush();
+  return true;
+}
+
+void mpsse_buffer_append_byte(uint8_t data) {
+  mpsse_buffer[mpsse_buffer_pos++] = data;
+}
+
+void mpsse_buffer_append(const uint8_t* data, size_t num_bytes) {
+  memcpy(mpsse_buffer + mpsse_buffer_pos, data, num_bytes);
+  mpsse_buffer_pos += num_bytes;
+}

--- a/src/mpsse_buffer.h
+++ b/src/mpsse_buffer.h
@@ -1,0 +1,10 @@
+#ifndef __MPSSE_BUFFER_H__
+#define __MPSSE_BUFFER_H__
+
+void mpsse_buffer_init(struct ftdi_context *ftdi);
+bool mpsse_buffer_ensure_space(size_t num_bytes);
+void mpsse_buffer_append_byte(uint8_t data);
+void mpsse_buffer_append(const uint8_t* data, size_t num_bytes);
+bool mpsse_buffer_flush();
+
+#endif

--- a/src/mpsse_buffer.h
+++ b/src/mpsse_buffer.h
@@ -1,6 +1,9 @@
 #ifndef __MPSSE_BUFFER_H__
 #define __MPSSE_BUFFER_H__
 
+#include <stddef.h>
+#include <stdint.h>
+
 void mpsse_buffer_init(struct ftdi_context *ftdi);
 bool mpsse_buffer_ensure_space(size_t num_bytes);
 void mpsse_buffer_append_byte(uint8_t data);

--- a/src/usb_blaster.cpp
+++ b/src/usb_blaster.cpp
@@ -39,7 +39,7 @@ uint8_t build_command(int tms, int tdi, int tck, bool read) {
   return command;
 }
 
-bool usb_blaster_init() {
+bool usb_blaster_init(enum AdapterTypes adapter_type) {
   printf("Initialize ftdi\n");
   ftdi = ftdi_new();
   assert(ftdi);

--- a/src/usb_blaster.h
+++ b/src/usb_blaster.h
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 
 // initialize usb_blaster interface of ftdi
-bool usb_blaster_init();
+bool usb_blaster_init(enum AdapterTypes adapter_type);
 bool usb_blaster_deinit();
 bool usb_blaster_set_tck_freq(uint64_t freq_mhz);
 


### PR DESCRIPTION
This set of patches adds support for the Digilent HS2 adapter.

I had some problems with "usb bulk write failed" errors. To solve them, all writes from `mpsse_jtag_scan_chain_send()` are now buffered first. They are only sent if 
- the buffer doesn't have space for another command or
- mpsse_jtag_scan_chain_receive() is called.

This already makes the errors occur less frequently. To totally get rid of them I had to increase the FTDI latency setting. To compensate the loss of speed, a `SEND_IMMEDIATE` command is appended to the buffer before commands are sent over USB. This improves the transfer speed considerably. In fact, on my machine the connection over xvc is as fast as if the adapter was connected directly.