### PR TITLE
Add support for multiple devices by selecting by USB bus and device address

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Then you can find `xc7a35t` device in Xilinx and you can debug remotely.
 
 For USB Blaster: `./jtag-remote-server -V 09fb -p 6001 -b`.
 
+When there are multiple FTDI devices on the same system it is possible to select a specific one using it's USB bus and device ID: `./jtag-remote-server -B 1 -D 2 -x` 
+
 ## Performance
 
 Some testing reveals that this tool can run at 14Mbps(rbb mode)/4Mbps(jtag_vpi mode)/3Mbps(xvc mode) when programming bitstream to FPGA. The speed of 14Mbps is mainly limited by the 15MHz jtag clock and could be improved by using a faster clock if the jtag tap can work under 30MHz(maximum clock frequency is 60MHz / 2). As per DS893, maximum TCK frequency of Xilinx Virtex Ultrascale devices is 20MHz(SLR-based) or 50MHz(others).

--- a/src/common.h
+++ b/src/common.h
@@ -51,6 +51,10 @@ extern int ftdi_vid;
 extern int ftdi_pid;
 extern enum ftdi_interface ftdi_channel;
 
+extern bool use_bus_addr;
+extern uint8_t usb_bus_addr;
+extern uint8_t usb_dev_addr;
+
 // jtag state transition
 JtagState next_state(JtagState cur, int bit);
 const char *state_to_string(JtagState state);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char *argv[]) {
   signal(SIGINT, sigint_handler);
   signal(SIGPIPE, SIG_IGN);
 
+  bool usb_vid_pid_used = false;
+  bool usb_bus_dev_used = false;
+
   // https://man7.org/linux/man-pages/man3/getopt.3.html
   int opt;
   Protocol proto = Protocol::VPI;
@@ -93,19 +96,21 @@ int main(int argc, char *argv[]) {
       }
       break;
     case 'V':
-      use_bus_addr = false;
+      usb_vid_pid_used = true;
       sscanf(optarg, "%x", &ftdi_vid);
       break;
     case 'p':
-      use_bus_addr = false;
+      usb_vid_pid_used = true;
       sscanf(optarg, "%x", &ftdi_pid);
       break;
     case 'B':
-      use_bus_addr = true;
+      use_bus_addr     = true;
+      usb_bus_dev_used = true;
       sscanf(optarg, "%" SCNu8, &usb_bus_addr);
       break;
     case 'D':
-      use_bus_addr = true;
+      use_bus_addr     = true;
+      usb_bus_dev_used = true;
       sscanf(optarg, "%" SCNu8, &usb_dev_addr);
       break;
     case 'f':
@@ -129,6 +134,11 @@ int main(int argc, char *argv[]) {
       fprintf(stderr, "\t-f FREQ: Specify jtag clock frequency in MHz\n");
       return 1;
     }
+  }
+
+  if (usb_vid_pid_used && usb_bus_dev_used) {
+    fprintf(stderr, "Cannot use PID/VID and BUS/DEV at the same time!\n");
+    return 1;
   }
 
   if (!adapter_init(adapter_type)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,10 @@ uint8_t buffer[BUFFER_SIZE];
 size_t buffer_begin = 0;
 size_t buffer_end = 0;
 
+bool use_bus_addr     = false;
+uint8_t usb_bus_addr  = 1;
+uint8_t usb_dev_addr  = 1;
+
 void sigint_handler(int sig) {
   printf("Gracefully shutdown\n");
   stop = true;
@@ -47,7 +51,7 @@ int main(int argc, char *argv[]) {
   // https://man7.org/linux/man-pages/man3/getopt.3.html
   int opt;
   Protocol proto = Protocol::VPI;
-  while ((opt = getopt(argc, argv, "dvrxjbc:V:p:f:a:")) != -1) {
+  while ((opt = getopt(argc, argv, "dvrxjbc:V:p:f:a:B:D:")) != -1) {
     switch (opt) {
     case 'd':
       debug = true;
@@ -89,10 +93,20 @@ int main(int argc, char *argv[]) {
       }
       break;
     case 'V':
+      use_bus_addr = false;
       sscanf(optarg, "%x", &ftdi_vid);
       break;
     case 'p':
+      use_bus_addr = false;
       sscanf(optarg, "%x", &ftdi_pid);
+      break;
+    case 'B':
+      use_bus_addr = true;
+      sscanf(optarg, "%" SCNu8, &usb_bus_addr);
+      break;
+    case 'D':
+      use_bus_addr = true;
+      sscanf(optarg, "%" SCNu8, &usb_dev_addr);
       break;
     case 'f':
       sscanf(optarg, "%" SCNu64, &freq_mhz);
@@ -110,6 +124,8 @@ int main(int argc, char *argv[]) {
       fprintf(stderr, "\t-c A|B|C|D: Select ftdi channel\n");
       fprintf(stderr, "\t-V VID: Specify usb vid\n");
       fprintf(stderr, "\t-p PID: Specify usb pid\n");
+      fprintf(stderr, "\t-B BUS: Specify usb bus addr\n");
+      fprintf(stderr, "\t-D DEV: Specify usb device addr\n");
       fprintf(stderr, "\t-f FREQ: Specify jtag clock frequency in MHz\n");
       return 1;
     }

--- a/src/mpsse.cpp
+++ b/src/mpsse.cpp
@@ -19,8 +19,16 @@ bool mpsse_init(enum AdapterTypes adapter_type) {
     return false;
   }
 
-  printf("Open device vid=0x%04x pid=0x%04x\n", ftdi_vid, ftdi_pid);
-  ret = ftdi_usb_open(ftdi, ftdi_vid, ftdi_pid);
+  if(use_bus_addr) {
+    printf("Open device bus=0x%04x dev=0x%04x\n", usb_bus_addr, usb_dev_addr);
+    ret = ftdi_usb_open_bus_addr(ftdi, usb_bus_addr, usb_dev_addr);
+  }
+  else {
+    printf("Open device vid=0x%04x pid=0x%04x\n", ftdi_vid, ftdi_pid);
+    ret = ftdi_usb_open(ftdi, ftdi_vid, ftdi_pid);
+  }
+
+
   if (ret) {
     printf("Error @ %s:%d : %s\n", __FILE__, __LINE__,
            ftdi_get_error_string(ftdi));


### PR DESCRIPTION
I want to use the tool on a system with multiple FTDI devices (all HS3) connected. But right now it's not possible because it only can select the first FTDI device. Adding support to select by bus and device address allows me this functionality.